### PR TITLE
Changed API key headers to new ArtifactHub API schema

### DIFF
--- a/request.py
+++ b/request.py
@@ -1,14 +1,27 @@
+import os
 import requests
 import json
 from datetime import datetime
 
 def get_packages():
-    print("Retrieving list of repos...")
+
+    # try to read API key information form environment
+    # export vars or replace the None with a valid API for local testing
+    API_KEY_ID = os.getenv('ARTIFACT_HUB_API_KEY_ID', None)
+    if API_KEY_ID is None:
+        raise ValueError("Artifact Hub API key ID is missing")
+    API_KEY_SECRET = os.getenv('ARTIFACT_HUB_API_KEY_SECRET', None)
+    if API_KEY_SECRET is None:
+        raise ValueError("Artifact Hub API key Secret is missing")
+
+    # API request common headers
     headers = {
         'accept': 'application/json',
-        'X-API-KEY': 'your-API-key-here'
+        'X-API-KEY-ID': API_KEY_ID,
+        'X-API-KEY-SECRET': API_KEY_SECRET
     }
 
+    print("Retrieving list of repos...")
     response = requests.get('https://artifacthub.io/api/v1/repositories', headers=headers)
     repos = response.json()
     with open(f'data/repos-{datetime.date(datetime.now())}.json', 'w') as f:
@@ -20,10 +33,6 @@ def get_packages():
         names.append(item['name'])
     count = 0
     packages = []
-    headers = {
-    'accept': 'application/json',
-    'X-API-KEY': 'your-API-key-here'
-    }
     for name in names:
         print(f"Collecting metadata from info {count + 1} of {len(names)}")
         params = (


### PR DESCRIPTION
- adopted to ArtifactHub API key naming changes
- added option to read API keys from environment

@EcePanos this is a first change to make the current version of the ArtifactHub Collector work again with the new API schema. Further "integration work" might follow later on a separate branch if necessary. Nevertheless I thought opening a PR for these changes right away makes sense in order to have a working version on the `main` upstream branch.